### PR TITLE
Fix invalid player data cache

### DIFF
--- a/src/main/java/com/github/ars_affinity/ArsAffinity.java
+++ b/src/main/java/com/github/ars_affinity/ArsAffinity.java
@@ -162,9 +162,13 @@ public class ArsAffinity {
     }
 
     private void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
-        PlayerAffinityDataProvider.savePlayerData(event.getEntity());
-        WetTicksProvider.savePlayerWetTicks(event.getEntity());
-        ActiveAbilityProvider.savePlayerData(event.getEntity());
+        Player player = event.getEntity();
+        PlayerAffinityDataProvider.savePlayerData(player);
+        WetTicksProvider.savePlayerWetTicks(player);
+        ActiveAbilityProvider.savePlayerData(player);
+        
+        PlayerAffinityDataProvider.removePlayerData(player);
+        ActiveAbilityProvider.removePlayerData(player);
     }
     
     private void onServerStopping(ServerStoppingEvent event) {

--- a/src/main/java/com/github/ars_affinity/capability/ActiveAbilityProvider.java
+++ b/src/main/java/com/github/ars_affinity/capability/ActiveAbilityProvider.java
@@ -88,4 +88,15 @@ public class ActiveAbilityProvider {
     public static int getCacheSize() {
         return playerDataCache.size();
     }
+    
+    public static void removePlayerData(UUID playerId) {
+        ActiveAbilityData removed = playerDataCache.remove(playerId);
+        if (removed != null) {
+            ArsAffinity.LOGGER.debug("Removed active ability data from cache for UUID: {}", playerId);
+        }
+    }
+    
+    public static void removePlayerData(Player player) {
+        removePlayerData(player.getUUID());
+    }
 }

--- a/src/main/java/com/github/ars_affinity/capability/PlayerAffinityData.java
+++ b/src/main/java/com/github/ars_affinity/capability/PlayerAffinityData.java
@@ -63,6 +63,10 @@ public class PlayerAffinityData implements INBTSerializable<CompoundTag> {
         this.player = player;
     }
     
+    public void clearPlayer() {
+        this.player = null;
+    }
+    
     private void markDirty() {
         this.isDirty = true;
     }

--- a/src/main/java/com/github/ars_affinity/capability/PlayerAffinityDataProvider.java
+++ b/src/main/java/com/github/ars_affinity/capability/PlayerAffinityDataProvider.java
@@ -106,4 +106,16 @@ public class PlayerAffinityDataProvider {
     public static int getCacheSize() {
         return playerDataCache.size();
     }
+    
+    public static void removePlayerData(UUID playerId) {
+        PlayerAffinityData removed = playerDataCache.remove(playerId);
+        if (removed != null) {
+            removed.clearPlayer();
+            ArsAffinity.LOGGER.debug("Removed player affinity data from cache for UUID: {}", playerId);
+        }
+    }
+    
+    public static void removePlayerData(Player player) {
+        removePlayerData(player.getUUID());
+    }
 }


### PR DESCRIPTION
Remove invalid Server Players from `playerDataCache` and `activeAbilityCache` to prevent stale references.

The `playerDataCache` and `activeAbilityCache` maps were not cleared on player disconnect, leading to stale player references persisting in the cache. This PR adds logic to remove player data from these caches when a player logs out, and also explicitly clears the player reference within `PlayerAffinityData` for additional safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-309ea8c9-5158-4256-9a98-c8d73853c0f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-309ea8c9-5158-4256-9a98-c8d73853c0f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Fixes issue https://github.com/zeroregard/Ars-Affinity/issues/40
