### PR TITLE
Fix issue 39 in Ars-Affinity

### DIFF
--- a/src/main/java/com/github/ars_affinity/client/screen/perk/PerkTooltipRenderer.java
+++ b/src/main/java/com/github/ars_affinity/client/screen/perk/PerkTooltipRenderer.java
@@ -42,7 +42,18 @@ public class PerkTooltipRenderer {
     
     private AbstractSpellPart getGlyphSpellPart(String glyphId) {
         try {
-            ResourceLocation glyphLocation = ResourceLocation.parse(glyphId);
+            if (glyphId == null || glyphId.isEmpty()) {
+                return null;
+            }
+            
+            String[] parts = glyphId.split(":", 2);
+            ResourceLocation glyphLocation;
+            if (parts.length == 2) {
+                glyphLocation = ResourceLocation.fromNamespaceAndPath(parts[0], parts[1]);
+            } else {
+                glyphLocation = ResourceLocation.fromNamespaceAndPath("minecraft", glyphId);
+            }
+            
             return GlyphRegistry.getSpellpartMap().get(glyphLocation);
         } catch (Exception e) {
             ArsAffinity.LOGGER.warn("Error getting glyph SpellPart for {}: {}", glyphId, e.getMessage());

--- a/src/main/java/com/github/ars_affinity/perk/GlyphPrerequisiteHelper.java
+++ b/src/main/java/com/github/ars_affinity/perk/GlyphPrerequisiteHelper.java
@@ -9,6 +9,19 @@ import net.minecraft.world.entity.player.Player;
 
 public class GlyphPrerequisiteHelper {
     
+    private static ResourceLocation parseResourceLocation(String id) {
+        if (id == null || id.isEmpty()) {
+            return null;
+        }
+        
+        String[] parts = id.split(":", 2);
+        if (parts.length == 2) {
+            return ResourceLocation.fromNamespaceAndPath(parts[0], parts[1]);
+        }
+        
+        return ResourceLocation.fromNamespaceAndPath("minecraft", id);
+    }
+    
     /**
      * Check if a player has unlocked a specific glyph.
      * @param player The player to check
@@ -17,24 +30,26 @@ public class GlyphPrerequisiteHelper {
      */
     public static boolean hasUnlockedGlyph(Player player, String glyphId) {
         if (player == null || glyphId == null || glyphId.isEmpty()) {
-            return true; // No prerequisite glyph means it's always unlocked
+            return true;
         }
         
         try {
-            ResourceLocation glyphLocation = ResourceLocation.parse(glyphId);
+            ResourceLocation glyphLocation = parseResourceLocation(glyphId);
+            if (glyphLocation == null) {
+                return false;
+            }
+            
             IPlayerCap playerCap = CapabilityRegistry.getPlayerDataCap(player);
             
             if (playerCap == null) {
                 return false;
             }
             
-            // Get the glyph from the registry
             AbstractSpellPart glyph = GlyphRegistry.getSpellpartMap().get(glyphLocation);
             if (glyph == null) {
                 return false;
             }
             
-            // Check if player knows this glyph
             return playerCap.knowsGlyph(glyph);
             
         } catch (Exception e) {
@@ -54,19 +69,21 @@ public class GlyphPrerequisiteHelper {
         }
         
         try {
-            ResourceLocation glyphLocation = ResourceLocation.parse(glyphId);
-            AbstractSpellPart glyph = GlyphRegistry.getSpellpartMap().get(glyphLocation);
-            
-            if (glyph != null) {
-                return glyph.getName();
+            ResourceLocation glyphLocation = parseResourceLocation(glyphId);
+            if (glyphLocation != null) {
+                AbstractSpellPart glyph = GlyphRegistry.getSpellpartMap().get(glyphLocation);
+                
+                if (glyph != null) {
+                    return glyph.getName();
+                }
             }
             
-            // Fallback to parsing the ID
             String[] parts = glyphId.split(":");
             if (parts.length >= 2) {
                 String glyphName = parts[1].replace("glyph_", "");
-                // Capitalize first letter
-                return glyphName.substring(0, 1).toUpperCase() + glyphName.substring(1);
+                if (!glyphName.isEmpty()) {
+                    return glyphName.substring(0, 1).toUpperCase() + glyphName.substring(1);
+                }
             }
             
             return glyphId;


### PR DESCRIPTION
Replaced `ResourceLocation.parse()` with a safer, consistent parsing method to fix glyph prerequisite issues.

The original `ResourceLocation.parse()` could fail when glyph IDs lacked an explicit namespace, causing incorrect prerequisite checks. The new method handles this by defaulting to the "minecraft" namespace and using `ResourceLocation.fromNamespaceAndPath()`, aligning with common practice in the codebase and improving robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5100403-35d0-4174-a044-32a075043a27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5100403-35d0-4174-a044-32a075043a27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

