### PR TITLE
Use WeakReference instead of hard references to player (Linguardium)

### DIFF
--- a/src/main/java/com/github/ars_affinity/ArsAffinity.java
+++ b/src/main/java/com/github/ars_affinity/ArsAffinity.java
@@ -174,6 +174,7 @@ public class ArsAffinity {
     }
     
     private void onServerStopping(ServerStoppingEvent event) {
+        ParticleUpdateScheduler.shutdown();
         PlayerAffinityDataProvider.saveAllData();
         PlayerAffinityDataProvider.clearCache();
         WetTicksProvider.clearCache();

--- a/src/main/java/com/github/ars_affinity/event/ParticleUpdateScheduler.java
+++ b/src/main/java/com/github/ars_affinity/event/ParticleUpdateScheduler.java
@@ -4,10 +4,12 @@ import com.github.ars_affinity.ArsAffinity;
 import com.github.ars_affinity.common.network.Networking;
 import com.github.ars_affinity.common.network.ParticleEffectPacket;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -15,62 +17,75 @@ import java.lang.ref.WeakReference;
 
 public class ParticleUpdateScheduler {
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-    private static final ConcurrentHashMap<String, ScheduledFuture> activeUpdates = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, ScheduledFuture<?>> activeUpdates = new ConcurrentHashMap<>();
+    private static volatile boolean isShutdown = false;
 
     public static void startPositionUpdates(Player player, String schoolId) {
-        if (!(player instanceof ServerPlayer serverPlayer)) return; // this should only ever be run for ServerPlayers (which only exist serverside)
+        if (isShutdown)
+            return;
+        if (!(player instanceof ServerPlayer serverPlayer))
+            return; // this should only ever be run for ServerPlayers (which only exist serverside)
         String key = serverPlayer.getId() + "_" + schoolId;
-        
+
         // DONT HOLD A HARD REFERENCE TO A PLAYER OBJECT OFF-THREAD! #memoryleaks
-        // WeakReference#get will return the referenced object if it still exists, or null if it has been garbage collected.
+        // WeakReference#get will return the referenced object if it still exists, or
+        // null if it has been garbage collected.
         // WeakReference allows garbage collection, preventing memory leaks
         WeakReference<ServerPlayer> playerRef = new WeakReference<>(serverPlayer);
-        
-        // Schedule position updates every 150ms (3 ticks at 20 TPS) for 3 seconds (60 ticks)
-        // take the returned Future to allow cancellation of the indefinite, repeating task
-        ScheduledFuture task = scheduler.scheduleAtFixedRate(() -> {
+
+        // Schedule position updates every 150ms (3 ticks at 20 TPS) for 3 seconds (60
+        // ticks)
+        // take the returned Future to allow cancellation of the indefinite, repeating
+        // task
+        ScheduledFuture<?> task = scheduler.scheduleAtFixedRate(() -> {
             if (activeUpdates.get(key) == null) {
-                throw new ExecutionException("Task " + key + " was removed from update list without cancelling"); // This will also cancel the task
+                throw new RuntimeException("Task " + key + " was removed from update list without cancelling"); // This
+                                                                                                                // will
+                                                                                                                // also
+                                                                                                                // cancel
+                                                                                                                // the
+                                                                                                                // task
             }
-            ServerPlayer player = playerRef.get();
-            if (player == null || player.hasDisconnected() || player.isRemoved() || !player.isAlive()) {
+            ServerPlayer refPlayer = playerRef.get();
+            if (refPlayer == null || refPlayer.hasDisconnected() || refPlayer.isRemoved() || !refPlayer.isAlive()) {
                 ParticleUpdateScheduler.stopPositionUpdates(key);
                 return; // Player is gone, stop updates
             }
-            
-            MinecraftServer server = player.getServer();
+
+            MinecraftServer server = refPlayer.getServer();
             if (server == null) {
                 ParticleUpdateScheduler.stopPositionUpdates(key);
                 return;
-            } // player doesnt belong to a server. this should probably throw but for now just cancel
-            
-            server.execute(() -> {
+            } // player doesnt belong to a server.
+              // this should probably throw but for now just cancel the task
 
-                ServerPlayer player = playerRef.get(); // if the player no longer exists by the time the server gets around to executing this, cancel the recurring task also
-                if (player == null || player.hasDisconnected() || player.isRemoved() || !player.isAlive()) {
+            server.execute(() -> {
+                ServerPlayer execPlayer = playerRef.get(); // if the player no longer exists by the time the server gets
+                                                           // around to executing this, cancel the recurring task also
+                if (execPlayer == null || execPlayer.hasDisconnected() || execPlayer.isRemoved()
+                        || !execPlayer.isAlive()) {
                     ParticleUpdateScheduler.stopPositionUpdates(key);
                     return;
                 }
 
-                var pos = player.position();
+                var pos = execPlayer.position();
                 var updatePacket = new ParticleEffectPacket(
-                    player.getId(),
-                    schoolId,
-                    pos.x,
-                    pos.y,
-                    pos.z
-                );
-                Networking.sendToNearbyClient(player.level(), player.blockPosition(), updatePacket);
-                ArsAffinity.LOGGER.debug("Sent position update for player {}: ({}, {}, {})", 
-                    player.getName().getString(), pos.x, pos.y, pos.z);
+                        execPlayer.getId(),
+                        schoolId,
+                        pos.x,
+                        pos.y,
+                        pos.z);
+                Networking.sendToNearbyClient(execPlayer.level(), execPlayer.blockPosition(), updatePacket);
+                ArsAffinity.LOGGER.debug("Sent position update for player {}: ({}, {}, {})",
+                        execPlayer.getName().getString(), pos.x, pos.y, pos.z);
             });
         }, 150, 150, TimeUnit.MILLISECONDS); // Start after 150ms, repeat every 150ms
 
         // store the new task, accepting the old stored task if there was one
-        ScheduledFuture oldTask = activeUpdates.put(key, task); 
+        ScheduledFuture<?> oldTask = activeUpdates.put(key, task);
         if (oldTask != null) {
             // Cancel any existing updates for this player/school combination
-            oldTask.cancel();
+            oldTask.cancel(false);
         }
 
         // Stop updates after 3 seconds (60 ticks)
@@ -78,16 +93,45 @@ public class ParticleUpdateScheduler {
             ParticleUpdateScheduler.stopPositionUpdates(key);
         }, 3000, TimeUnit.MILLISECONDS);
     }
-    
+
     public static void stopPositionUpdates(Player player, String schoolId) {
         String key = player.getId() + "_" + schoolId;
         stopPositionUpdates(key);
     }
-    // required to be able to cancel the task if the player or network id is no longer in use
+
+    // required to be able to cancel the task if the player or network id is no
+    // longer in use
     public static void stopPositionUpdates(String key) {
-        ScheduledFuture task = activeUpdates.remove(key);
+        ScheduledFuture<?> task = activeUpdates.remove(key);
         if (task != null) {
-            task.cancel();
+            task.cancel(false);
         }
+    }
+
+    public static void shutdown() {
+        if (isShutdown)
+            return;
+        isShutdown = true;
+
+        for (ScheduledFuture<?> task : activeUpdates.values()) {
+            task.cancel(false);
+        }
+        activeUpdates.clear();
+
+        scheduler.shutdown();
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                ArsAffinity.LOGGER.warn("ParticleUpdateScheduler did not terminate within 5 seconds, forcing shutdown");
+                scheduler.shutdownNow();
+                if (!scheduler.awaitTermination(2, TimeUnit.SECONDS)) {
+                    ArsAffinity.LOGGER.error("ParticleUpdateScheduler did not terminate after force shutdown");
+                }
+            }
+        } catch (InterruptedException e) {
+            ArsAffinity.LOGGER.warn("Interrupted while shutting down ParticleUpdateScheduler, forcing shutdown");
+            scheduler.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        ;
     }
 }

--- a/src/main/java/com/github/ars_affinity/event/ParticleUpdateScheduler.java
+++ b/src/main/java/com/github/ars_affinity/event/ParticleUpdateScheduler.java
@@ -11,55 +11,83 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import java.lang.ref.WeakReference;
+
 public class ParticleUpdateScheduler {
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-    private static final ConcurrentHashMap<String, Boolean> activeUpdates = new ConcurrentHashMap<>();
-    
+    private static final ConcurrentHashMap<String, ScheduledFuture> activeUpdates = new ConcurrentHashMap<>();
+
     public static void startPositionUpdates(Player player, String schoolId) {
-        String key = player.getId() + "_" + schoolId;
+        if (!(player instanceof ServerPlayer serverPlayer)) return; // this should only ever be run for ServerPlayers (which only exist serverside)
+        String key = serverPlayer.getId() + "_" + schoolId;
         
-        // Cancel any existing updates for this player/school combination
-        activeUpdates.put(key, true);
+        // DONT HOLD A HARD REFERENCE TO A PLAYER OBJECT OFF-THREAD! #memoryleaks
+        // WeakReference#get will return the referenced object if it still exists, or null if it has been garbage collected.
+        // WeakReference allows garbage collection, preventing memory leaks
+        WeakReference<ServerPlayer> playerRef = new WeakReference<>(serverPlayer);
         
         // Schedule position updates every 150ms (3 ticks at 20 TPS) for 3 seconds (60 ticks)
-        scheduler.scheduleAtFixedRate(() -> {
-            if (!activeUpdates.getOrDefault(key, false)) {
-                return; // Update was cancelled
+        // take the returned Future to allow cancellation of the indefinite, repeating task
+        ScheduledFuture task = scheduler.scheduleAtFixedRate(() -> {
+            if (activeUpdates.get(key) == null) {
+                throw new ExecutionException("Task " + key + " was removed from update list without cancelling"); // This will also cancel the task
             }
-            
-            if (player.isRemoved() || !player.isAlive()) {
-                activeUpdates.remove(key);
+            ServerPlayer player = playerRef.get();
+            if (player == null || player.hasDisconnected() || player.isRemoved() || !player.isAlive()) {
+                ParticleUpdateScheduler.stopPositionUpdates(key);
                 return; // Player is gone, stop updates
             }
             
             MinecraftServer server = player.getServer();
-            if (server != null) {
-                server.execute(() -> {
-                    if (player.isAlive() && !player.isRemoved()) {
-                        var pos = player.position();
-                        var updatePacket = new ParticleEffectPacket(
-                            player.getId(),
-                            schoolId,
-                            pos.x,
-                            pos.y,
-                            pos.z
-                        );
-                        Networking.sendToNearbyClient(player.level(), player.blockPosition(), updatePacket);
-                        ArsAffinity.LOGGER.debug("Sent position update for player {}: ({}, {}, {})", 
-                            player.getName().getString(), pos.x, pos.y, pos.z);
-                    }
-                });
-            }
+            if (server == null) {
+                ParticleUpdateScheduler.stopPositionUpdates(key);
+                return;
+            } // player doesnt belong to a server. this should probably throw but for now just cancel
+            
+            server.execute(() -> {
+
+                ServerPlayer player = playerRef.get(); // if the player no longer exists by the time the server gets around to executing this, cancel the recurring task also
+                if (player == null || player.hasDisconnected() || player.isRemoved() || !player.isAlive()) {
+                    ParticleUpdateScheduler.stopPositionUpdates(key);
+                    return;
+                }
+
+                var pos = player.position();
+                var updatePacket = new ParticleEffectPacket(
+                    player.getId(),
+                    schoolId,
+                    pos.x,
+                    pos.y,
+                    pos.z
+                );
+                Networking.sendToNearbyClient(player.level(), player.blockPosition(), updatePacket);
+                ArsAffinity.LOGGER.debug("Sent position update for player {}: ({}, {}, {})", 
+                    player.getName().getString(), pos.x, pos.y, pos.z);
+            });
         }, 150, 150, TimeUnit.MILLISECONDS); // Start after 150ms, repeat every 150ms
-        
+
+        // store the new task, accepting the old stored task if there was one
+        ScheduledFuture oldTask = activeUpdates.put(key, task); 
+        if (oldTask != null) {
+            // Cancel any existing updates for this player/school combination
+            oldTask.cancel();
+        }
+
         // Stop updates after 3 seconds (60 ticks)
         scheduler.schedule(() -> {
-            activeUpdates.remove(key);
+            ParticleUpdateScheduler.stopPositionUpdates(key);
         }, 3000, TimeUnit.MILLISECONDS);
     }
     
     public static void stopPositionUpdates(Player player, String schoolId) {
         String key = player.getId() + "_" + schoolId;
-        activeUpdates.remove(key);
+        stopPositionUpdates(key);
+    }
+    // required to be able to cancel the task if the player or network id is no longer in use
+    public static void stopPositionUpdates(String key) {
+        ScheduledFuture task = activeUpdates.remove(key);
+        if (task != null) {
+            task.cancel();
+        }
     }
 }


### PR DESCRIPTION
Continuation of https://github.com/zeroregard/Ars-Affinity/pull/50

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Particle update scheduling overhaul**
> 
> - Replace `activeUpdates` boolean map with `ScheduledFuture` tracking to support explicit cancellation
> - Use `WeakReference<ServerPlayer>` and verify `ServerPlayer` state (disconnected/removed/alive) before dispatching updates
> - Add `stopPositionUpdates(String key)` helper and ensure tasks self-cancel when player/server becomes invalid
> - Introduce `shutdown()` to cancel all tasks and terminate the scheduler; call it from `onServerStopping`
> - Guard against use after shutdown and ensure server-thread execution for packet sending
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ffdc198f9d16b0e7aebc58f43205b41045289a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->